### PR TITLE
plainify: rewrite prose into plain English, under word and vocabulary constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ tree-sitter masks every non-prose byte before detectors run, so hits land only o
 | Command | What it does |
 | --- | --- |
 | `check [path\|-]` | Run detectors; emit the JSON report. |
+| `plainify [path\|-]` | Rewrite prose into plain English with the `claude` CLI, under optional length and vocabulary constraints. |
 | `rewrite [path\|-]` | Rewrite a paragraph via the `claude` CLI, optionally targeting `--rules`. |
 | `rules` | Print the rule catalogue as JSON; filter with `--category` or `--llm-only`. |
 | `version` | Print build metadata as JSON. |
@@ -102,7 +103,11 @@ Input is the positional argument; pass `-` or omit it to read stdin. Run `slop-c
 
 ## How it works
 
-The interface assumes an agent is driving, so slop-cop prints JSON on stdout and diagnostics on stderr, with no TUI, no highlighting, and no prompts. `check` runs the 178 instant client-side rules, regex and structural, then up to two Claude-backed tiers. The sentence tier adds 40 rules on Claude Haiku under `--llm`, the document tier adds 8 more on Claude Sonnet under `--llm-deep`, and the full catalogue is 226 rules. `--llm-effort` is the underlying control, taking `off`, `low`, `high`, or `auto`. The default `auto` resolves to `low` whenever the `claude` CLI is on `$PATH`, so the sentence tier runs and the slower document tier waits for an explicit `--llm-deep`. An auto-enabled pass that fails reports the error in the report's `llm` field while the client-side results still return. The LLM tiers and `rewrite` drive the `claude` CLI, so slop-cop never needs an Anthropic API key; it rides your Claude subscription.
+The interface assumes an agent is driving, so slop-cop prints JSON on stdout and diagnostics on stderr, with no TUI, no highlighting, and no prompts. `check` runs the 178 instant client-side rules, regex and structural, then up to two Claude-backed tiers. The sentence tier adds 40 rules on Claude Haiku under `--llm`, the document tier adds 8 more on Claude Sonnet under `--llm-deep`, and the full catalogue is 226 rules. `--llm-effort` is the underlying control, taking `off`, `low`, `high`, or `auto`. The default `auto` resolves to `low` whenever the `claude` CLI is on `$PATH`, so the sentence tier runs and the slower document tier waits for an explicit `--llm-deep`. An auto-enabled pass that fails reports the error in the report's `llm` field while the client-side results still return. The LLM tiers, `rewrite`, and `plainify` drive the `claude` CLI, so slop-cop never needs an Anthropic API key; it rides your Claude subscription.
+
+`plainify` turns prose written for insiders into prose a reader outside the project can follow on one pass. The contract is fixed. Keep every fact, name, number, and file path, write short sentences in everyday words, and leave fenced and inline code alone. `--max-words` and `--forbid <regex>` reach the model as instructions and are graded again once it answers, so `--forbid '\b(DQ|A|Q|V)\d+\b'` catches the register id the rewrite kept.
+
+A rewrite that misses either constraint is retried once with its misses named, and what the retry still misses lands in the report's `truncated` and `violations` fields instead of being dropped. `--name-by-title` asks for titles in place of identifiers, and `--glossary <file>` hands the model the JSON map from one to the other. `--json` reads an array of `{"id","text"}` entries, runs a call per entry, and returns one result per entry in order.
 
 When the base layer runs over at least 100 words of prose, the report also carries an advisory `readability` object with estimated Flesch reading-ease and grade-level scores. It never produces a violation and never moves the exit code; it is a number to track across revisions, and it disappears under `--standard=slop`.
 

--- a/cmd/slop-cop/main.go
+++ b/cmd/slop-cop/main.go
@@ -73,6 +73,7 @@ Exit codes:
 	// the plugin installer compares it against the release tag.
 	root.SetVersionTemplate("{{.Version}}\n")
 	root.AddCommand(newCheckCmd())
+	root.AddCommand(newPlainifyCmd())
 	root.AddCommand(newRewriteCmd())
 	root.AddCommand(newRulesCmd())
 	root.AddCommand(newVersionCmd())

--- a/cmd/slop-cop/plainify.go
+++ b/cmd/slop-cop/plainify.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/yasyf/slop-cop/internal/llm"
+)
+
+// plainifyResult is the JSON document `slop-cop plainify` returns for one
+// piece of prose.
+type plainifyResult struct {
+	Plain      string               `json:"plain"`
+	Words      int                  `json:"words"`
+	Truncated  bool                 `json:"truncated"`
+	Violations []llm.PlainViolation `json:"violations"`
+}
+
+// plainifyEntryResult is one element of the array --json prints, carrying the
+// id its entry arrived with.
+type plainifyEntryResult struct {
+	ID string `json:"id"`
+	plainifyResult
+}
+
+func newPlainifyCmd() *cobra.Command {
+	var (
+		batch       bool
+		maxWords    int
+		forbid      []string
+		nameByTitle bool
+		glossary    string
+		model       string
+		timeout     time.Duration
+	)
+	cmd := &cobra.Command{
+		Use:   "plainify [path|-]",
+		Short: "Rewrite prose into plain English via `claude -p`.",
+		Long: `Sends the input text to the claude CLI with the plainify system prompt and
+prints a JSON document holding the plain-English rewrite.
+
+The contract is the same every call: keep every fact, name, number, and file
+path; short sentences and everyday words; fenced and inline code left
+unchanged; the rewrite alone, with no preamble or labels.
+
+--max-words and --forbid reach the model as instructions and are graded again
+after it answers. A rewrite that misses either is retried once with its misses
+named; what the retry still misses is reported in "truncated" and "violations"
+rather than dropped.
+
+--json reads a JSON array of {"id","text"} entries instead of one piece of
+prose, runs one call per entry, and prints one result per entry in the order
+they arrived.`,
+		Example: `  slop-cop plainify draft.md
+  slop-cop plainify - --max-words 120 < draft.md
+  slop-cop plainify findings.json --json --forbid '\b(DQ|A|Q|V)\d+\b' --name-by-title --glossary titles.json`,
+		Args: cobra.MaximumNArgs(1),
+	}
+	pretty := addPrettyFlag(cmd)
+	cmd.Flags().BoolVar(&batch, "json", false, `Read a JSON array of {"id","text"} entries and emit one result per entry.`)
+	cmd.Flags().IntVar(&maxWords, "max-words", 0, "Word budget for the rewrite; 0 sets none.")
+	cmd.Flags().StringArrayVar(&forbid, "forbid", nil, "Regular expression the rewrite must not match; repeatable.")
+	cmd.Flags().BoolVar(&nameByTitle, "name-by-title", false, "Name referenced items by their titles rather than their identifiers.")
+	cmd.Flags().StringVar(&glossary, "glossary", "", `Path to a JSON object mapping identifier to title, e.g. {"DQ4":"Worker transport"}.`)
+	cmd.Flags().StringVar(&model, "model", llm.DefaultRewriteModel, "Model slug for the plainify call.")
+	cmd.Flags().DurationVar(&timeout, "timeout", llm.DefaultRewriteTimeout, "Timeout for each plainify call.")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		text, err := readInput(pathArg(args))
+		if err != nil {
+			return err
+		}
+		constraints, err := resolvePlainifyConstraints(maxWords, forbid, nameByTitle, glossary)
+		if err != nil {
+			return err
+		}
+		ctx := runContext(cmd)
+		opts := llm.Options{Model: model, Timeout: timeout}
+
+		if !batch {
+			res, err := llm.Plainify(ctx, text, constraints, opts)
+			if err != nil {
+				return llmError{err: err}
+			}
+			return writeJSON(newPlainifyResult(res), *pretty)
+		}
+
+		var entries []llm.PlainEntry
+		if err := json.Unmarshal([]byte(text), &entries); err != nil {
+			return fmt.Errorf("decoding --json entries: %w", err)
+		}
+		// A JSON null decodes to a nil slice without erroring; an empty array
+		// decodes non-nil and is a real answer.
+		if entries == nil {
+			return fmt.Errorf(`decoding --json entries: want an array of {"id","text"}, got null`)
+		}
+		results, err := llm.PlainifyBatch(ctx, entries, constraints, opts)
+		if err != nil {
+			return llmError{err: err}
+		}
+		out := make([]plainifyEntryResult, len(results))
+		for i, res := range results {
+			out[i] = plainifyEntryResult{ID: entries[i].ID, plainifyResult: newPlainifyResult(res)}
+		}
+		return writeJSON(out, *pretty)
+	}
+	return cmd
+}
+
+func newPlainifyResult(res llm.PlainResult) plainifyResult {
+	return plainifyResult{
+		Plain:      res.Plain,
+		Words:      res.Words,
+		Truncated:  res.Truncated,
+		Violations: res.Violations,
+	}
+}
+
+// resolvePlainifyConstraints compiles the constraint flags into the shape the
+// llm layer takes, mapping a bad pattern or budget to a usage error and an
+// unreadable glossary to an IO error.
+func resolvePlainifyConstraints(maxWords int, forbid []string, nameByTitle bool, glossaryPath string) (llm.PlainifyConstraints, error) {
+	c := llm.PlainifyConstraints{MaxWords: maxWords, NameByTitle: nameByTitle}
+	if maxWords < 0 {
+		return c, usageError{err: fmt.Errorf("--max-words must not be negative: %d", maxWords)}
+	}
+	c.Forbid = make([]*regexp.Regexp, 0, len(forbid))
+	for _, pattern := range forbid {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return c, usageError{err: fmt.Errorf("--forbid %s: %w", pattern, err)}
+		}
+		c.Forbid = append(c.Forbid, re)
+	}
+	if glossaryPath == "" {
+		return c, nil
+	}
+	raw, err := os.ReadFile(glossaryPath) //nolint:gosec // G304: path is the user-supplied --glossary argument this command is designed to read.
+	if err != nil {
+		return c, fmt.Errorf("reading %s: %w", glossaryPath, err)
+	}
+	if err := json.Unmarshal(raw, &c.Glossary); err != nil {
+		return c, fmt.Errorf("decoding %s: %w", glossaryPath, err)
+	}
+	return c, nil
+}

--- a/cmd/slop-cop/plainify_test.go
+++ b/cmd/slop-cop/plainify_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runPlainify executes the plainify command in-process and returns the raw
+// bytes it wrote to stdout. writeJSON encodes straight to os.Stdout, so the fd
+// is redirected to a temp file for the duration of the call.
+func runPlainify(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = f
+	cmd := newPlainifyCmd()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs(args)
+	runErr := cmd.Execute()
+	os.Stdout = orig
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out), runErr
+}
+
+// claudeReplying puts a claude stub on an otherwise-empty $PATH that answers
+// every call with the same rewrite, and returns the path it logs each call's
+// arguments to.
+func claudeReplying(t *testing.T, plain string) string {
+	t.Helper()
+	dir := t.TempDir()
+	payload, err := json.Marshal(map[string]string{"plain": plain})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := []map[string]any{{
+		"type":              "result",
+		"subtype":           "success",
+		"is_error":          false,
+		"result":            string(payload),
+		"structured_output": json.RawMessage(payload),
+	}}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := filepath.Join(dir, "response.json")
+	//nolint:gosec // G306: a fixture in a test-owned temp dir.
+	if err := os.WriteFile(response, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	argsLog := filepath.Join(dir, "args")
+	script := fmt.Sprintf("#!/bin/sh\n/bin/cat > /dev/null\nprintf '%%s\\n' \"$*\" >> %q\nexec /bin/cat %q\n", argsLog, response)
+	bin := t.TempDir()
+	//nolint:gosec // G306: an executable stub on a test-owned temp PATH.
+	if err := os.WriteFile(filepath.Join(bin, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+	return argsLog
+}
+
+func writeTemp(t *testing.T, name, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	//nolint:gosec // G306: a fixture in a test-owned temp dir.
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestPlainifyCommandReport pins the single-input envelope: the rewrite, its
+// word count, and both constraint fields, with violations an empty array
+// rather than null.
+func TestPlainifyCommandReport(t *testing.T) {
+	claudeReplying(t, "The worker moved to the new transport.")
+	draft := writeTemp(t, "draft.md", "We leveraged a novel transport abstraction.")
+
+	out, err := runPlainify(t, draft)
+	if err != nil {
+		t.Fatalf("plainify: %v", err)
+	}
+	var got plainifyResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, out)
+	}
+	if got.Plain != "The worker moved to the new transport." {
+		t.Fatalf("plain=%q", got.Plain)
+	}
+	if got.Words != 7 || got.Truncated {
+		t.Fatalf("words=%d truncated=%v, want 7 and false", got.Words, got.Truncated)
+	}
+	if !json.Valid([]byte(out)) || !strings.Contains(out, `"violations":[]`) {
+		t.Fatalf("violations did not serialise as an empty array:\n%s", out)
+	}
+}
+
+// TestPlainifyCommandJSONMode covers the batch contract: an array in, an array
+// of the same length and order out, each element carrying its entry's id.
+func TestPlainifyCommandJSONMode(t *testing.T) {
+	claudeReplying(t, "The worker moved.")
+	entries := writeTemp(t, "entries.json", `[
+	  {"id": "DQ4", "text": "We leveraged a novel transport abstraction."},
+	  {"id": "DQ7", "text": "The subsystem exhibits nondeterministic characteristics."}
+	]`)
+
+	out, err := runPlainify(t, entries, "--json")
+	if err != nil {
+		t.Fatalf("plainify --json: %v", err)
+	}
+	var got []plainifyEntryResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, out)
+	}
+	if len(got) != 2 {
+		t.Fatalf("results=%d, want 2:\n%s", len(got), out)
+	}
+	for i, wantID := range []string{"DQ4", "DQ7"} {
+		if got[i].ID != wantID {
+			t.Fatalf("result %d has id %q, want %q", i, got[i].ID, wantID)
+		}
+		if got[i].Plain != "The worker moved." || got[i].Words != 3 {
+			t.Fatalf("result %d is %+v", i, got[i])
+		}
+	}
+}
+
+// TestPlainifyCommandJSONModeRejectsNull covers the one non-array input JSON
+// decodes without complaint: null would otherwise print an empty array and
+// exit 0, while an empty array is a real answer.
+func TestPlainifyCommandJSONModeRejectsNull(t *testing.T) {
+	claudeReplying(t, "unused")
+
+	if _, err := runPlainify(t, writeTemp(t, "null.json", "null"), "--json"); err == nil {
+		t.Fatal("expected null entries to fail")
+	}
+	out, err := runPlainify(t, writeTemp(t, "empty.json", "[]"), "--json")
+	if err != nil {
+		t.Fatalf("plainify --json on an empty array: %v", err)
+	}
+	if strings.TrimSpace(out) != "[]" {
+		t.Fatalf("empty array printed %q, want []", out)
+	}
+}
+
+// TestPlainifyCommandReportsSurvivingViolations proves a forbidden id the
+// model kept lands in the report instead of being scrubbed or erroring out.
+func TestPlainifyCommandReportsSurvivingViolations(t *testing.T) {
+	claudeReplying(t, "DQ4 moved.")
+	draft := writeTemp(t, "draft.md", "DQ4 was migrated.")
+
+	out, err := runPlainify(t, draft, "--forbid", `\b(DQ|A|Q|V)\d+\b`)
+	if err != nil {
+		t.Fatalf("plainify: %v", err)
+	}
+	var got plainifyResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, out)
+	}
+	if got.Plain != "DQ4 moved." {
+		t.Fatalf("plain=%q, want the model's answer untouched", got.Plain)
+	}
+	if len(got.Violations) != 1 || got.Violations[0].Match != "DQ4" {
+		t.Fatalf("violations=%+v, want one DQ4 match", got.Violations)
+	}
+}
+
+// TestPlainifyCommandGlossaryReachesTheModel closes the loop on --glossary and
+// --name-by-title: both land in the system prompt claude is invoked with.
+func TestPlainifyCommandGlossaryReachesTheModel(t *testing.T) {
+	argsLog := claudeReplying(t, "The worker transport moved.")
+	glossary := writeTemp(t, "titles.json", `{"DQ4": "Worker transport"}`)
+	draft := writeTemp(t, "draft.md", "DQ4 was migrated.")
+
+	if _, err := runPlainify(t, draft, "--name-by-title", "--glossary", glossary); err != nil {
+		t.Fatalf("plainify: %v", err)
+	}
+	//nolint:gosec // G304: a test-owned temp path, not user input.
+	args, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Name every item you refer to by its title", `DQ4 is titled "Worker transport"`} {
+		if !strings.Contains(string(args), want) {
+			t.Fatalf("the system prompt is missing %q:\n%s", want, args)
+		}
+	}
+}
+
+// TestPlainifyCommandRejectsBadFlags maps each malformed constraint to the
+// usage exit class rather than a claude call.
+func TestPlainifyCommandRejectsBadFlags(t *testing.T) {
+	draft := writeTemp(t, "draft.md", "prose")
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"unparsable forbid pattern", []string{draft, "--forbid", "("}},
+		{"negative word budget", []string{draft, "--max-words", "-1"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := runPlainify(t, c.args...)
+			if err == nil {
+				t.Fatal("expected a usage error")
+			}
+			if !errors.As(err, new(usageError)) {
+				t.Fatalf("error %v is not a usageError", err)
+			}
+		})
+	}
+}

--- a/internal/llm/plainify.go
+++ b/internal/llm/plainify.go
@@ -1,0 +1,214 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// plainifyConcurrency caps the claude processes one batch runs at once. A
+// register of findings arrives as a single array and each entry is its own
+// call, so the fan-out is the caller's array length rather than a document's
+// chunk count.
+const plainifyConcurrency = 4
+
+// PlainifySchema is the JSON schema for plainify responses.
+const PlainifySchema = `{
+  "type": "object",
+  "properties": {
+    "plain": {"type": "string"}
+  },
+  "required": ["plain"]
+}`
+
+// plainifyPreamble opens every plainify system prompt.
+const plainifyPreamble = "You are an expert editor. Rewrite the given text in plain English that a reader outside the project can follow on one pass. Apply all of these principles:"
+
+// plainifyPrinciples are the standing contract: the rewrite says what the
+// original said, in words a general reader already knows.
+var plainifyPrinciples = []string{
+	"- Keep every fact, name, number, and file path exactly as the original has it.",
+	"- Write short sentences. One idea per sentence.",
+	"- Use everyday words. Where the original reaches for jargon, say the plain thing it means.",
+	"- Leave fenced code blocks and inline code spans byte for byte unchanged.",
+	"- Add nothing the original does not say, and drop nothing it does.",
+	"- Return the rewrite alone: no preamble, no labels, no commentary.",
+}
+
+// PlainifyConstraints are the caller's limits on a rewrite. MaxWords and
+// Forbid reach the model as instructions and are also graded afterwards, so
+// a rewrite that ignores them is caught rather than trusted.
+type PlainifyConstraints struct {
+	// MaxWords bounds the rewrite's whitespace-separated word count; zero
+	// means no bound.
+	MaxWords int
+	// Forbid are patterns the rewrite must not match, such as the register
+	// ids a reader outside the project cannot resolve.
+	Forbid []*regexp.Regexp
+	// NameByTitle asks the model to name referenced items by their titles
+	// rather than their identifiers.
+	NameByTitle bool
+	// Glossary maps an identifier to the title that names it.
+	Glossary map[string]string
+}
+
+// PlainViolation is one match of a --forbid pattern that survived the retry.
+type PlainViolation struct {
+	Pattern string `json:"pattern"`
+	Match   string `json:"match"`
+}
+
+// PlainResult is a graded rewrite: the text plus what it did with the
+// constraints. Truncated reports that the rewrite still runs past MaxWords,
+// and Violations carries every forbidden match still in it.
+type PlainResult struct {
+	Plain      string
+	Words      int
+	Truncated  bool
+	Violations []PlainViolation
+}
+
+// PlainEntry is one element of the array `plainify --json` reads.
+type PlainEntry struct {
+	ID   string `json:"id"`
+	Text string `json:"text"`
+}
+
+// BuildPlainifySystemPrompt renders the plain-English contract plus whatever
+// constraints the caller set.
+func BuildPlainifySystemPrompt(c PlainifyConstraints) string {
+	base := plainifyPreamble + "\n" + strings.Join(plainifyPrinciples, "\n")
+	directives := c.directives()
+	if len(directives) == 0 {
+		return base
+	}
+	return base + "\n\nThe rewrite also has to meet these constraints:\n" + strings.Join(directives, "\n")
+}
+
+func (c PlainifyConstraints) directives() []string {
+	var out []string
+	if c.MaxWords > 0 {
+		out = append(out, fmt.Sprintf("- Use at most %d words.", c.MaxWords))
+	}
+	for _, re := range c.Forbid {
+		out = append(out, fmt.Sprintf("- No part of the rewrite may match the regular expression %s.", re.String()))
+	}
+	if c.NameByTitle {
+		out = append(out, "- Name every item you refer to by its title. Never print its identifier.")
+	}
+	if len(c.Glossary) > 0 {
+		out = append(out, "- The titles for the identifiers in the original:")
+		for _, id := range sortedKeys(c.Glossary) {
+			out = append(out, fmt.Sprintf("  - %s is titled %q.", id, c.Glossary[id]))
+		}
+	}
+	return out
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// grade measures a candidate rewrite against the constraints.
+func (c PlainifyConstraints) grade(plain string) PlainResult {
+	violations := []PlainViolation{}
+	for _, re := range c.Forbid {
+		for _, match := range re.FindAllString(plain, -1) {
+			violations = append(violations, PlainViolation{Pattern: re.String(), Match: match})
+		}
+	}
+	words := len(strings.Fields(plain))
+	return PlainResult{
+		Plain:      plain,
+		Words:      words,
+		Truncated:  c.MaxWords > 0 && words > c.MaxWords,
+		Violations: violations,
+	}
+}
+
+// retryDirectives names what a graded rewrite got wrong, one line per miss,
+// for the second attempt's system prompt. An empty result means the rewrite
+// met every constraint.
+func (r PlainResult) retryDirectives(c PlainifyConstraints) []string {
+	var out []string
+	if r.Truncated {
+		out = append(out, fmt.Sprintf("- Your last attempt ran to %d words against a limit of %d. Cut it to at most %d.", r.Words, c.MaxWords, c.MaxWords))
+	}
+	for _, v := range r.Violations {
+		out = append(out, fmt.Sprintf("- Your last attempt matched the forbidden pattern %s at %q. Say that another way.", v.Pattern, v.Match))
+	}
+	return out
+}
+
+type plainifyEnvelope struct {
+	Plain string `json:"plain"`
+}
+
+// Plainify sends text through claude with the plain-English contract. A
+// rewrite that misses a constraint is retried once with its misses named,
+// and the second attempt's grade is what comes back, met or not.
+func Plainify(ctx context.Context, text string, c PlainifyConstraints, opts Options) (PlainResult, error) {
+	cfg := opts.config(DefaultRewriteModel, DefaultRewriteTimeout)
+	system := BuildPlainifySystemPrompt(c)
+
+	plain, err := callPlainify(ctx, cfg, system, text)
+	if err != nil {
+		return PlainResult{}, err
+	}
+	graded := c.grade(plain)
+	misses := graded.retryDirectives(c)
+	if len(misses) == 0 {
+		return graded, nil
+	}
+
+	tighter := system + "\n\nYour last attempt broke these constraints. Fix them, and change nothing else:\n" + strings.Join(misses, "\n")
+	plain, err = callPlainify(ctx, cfg, tighter, text)
+	if err != nil {
+		return PlainResult{}, err
+	}
+	return c.grade(plain), nil
+}
+
+// PlainifyBatch plainifies each entry on its own call and returns the results
+// in the order the entries arrived. One failed entry fails the batch.
+func PlainifyBatch(ctx context.Context, entries []PlainEntry, c PlainifyConstraints, opts Options) ([]PlainResult, error) {
+	results := make([]PlainResult, len(entries))
+	errs := make([]error, len(entries))
+	slots := make(chan struct{}, plainifyConcurrency)
+
+	var wg sync.WaitGroup
+	for i, entry := range entries {
+		wg.Add(1)
+		go func(i int, entry PlainEntry) {
+			defer wg.Done()
+			slots <- struct{}{}
+			defer func() { <-slots }()
+			results[i], errs[i] = Plainify(ctx, entry.Text, c, opts)
+		}(i, entry)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			return nil, fmt.Errorf("entry %s: %w", entries[i].ID, err)
+		}
+	}
+	return results, nil
+}
+
+func callPlainify(ctx context.Context, cfg Config, system, text string) (string, error) {
+	var env plainifyEnvelope
+	if err := RunSchema(ctx, cfg, system, text, json.RawMessage(PlainifySchema), &env); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(env.Plain), nil
+}

--- a/internal/llm/plainify_test.go
+++ b/internal/llm/plainify_test.go
@@ -1,0 +1,269 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writePlainResponse renders one captured-shape `claude -p --output-format
+// json` reply — the stream array whose terminal type=="result" element carries
+// the schema payload — for a given rewrite.
+func writePlainResponse(t *testing.T, path, plain string) {
+	t.Helper()
+	payload, err := json.Marshal(plainifyEnvelope{Plain: plain})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := []map[string]any{
+		{"type": "system", "subtype": "init"},
+		{"type": "assistant"},
+		{
+			"type":              "result",
+			"subtype":           "success",
+			"is_error":          false,
+			"result":            string(payload),
+			"structured_output": json.RawMessage(payload),
+		},
+	}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//nolint:gosec // G306: a fixture in a test-owned temp dir.
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// fakeClaudeSequence puts a claude stub on an otherwise-empty $PATH that
+// answers the Nth call with plains[N-1] and appends each call's arguments to
+// the returned log file, so a test can read back the system prompt each
+// attempt was given.
+func fakeClaudeSequence(t *testing.T, plains ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for i, plain := range plains {
+		writePlainResponse(t, filepath.Join(dir, fmt.Sprintf("%d.json", i+1)), plain)
+	}
+	counter := filepath.Join(dir, "calls")
+	argsLog := filepath.Join(dir, "args")
+	script := fmt.Sprintf(`#!/bin/sh
+/bin/cat > /dev/null
+printf '%%s\n' "$*" >> %[1]q
+n=0
+if [ -f %[2]q ]; then n=$(/bin/cat %[2]q); fi
+n=$((n+1))
+printf '%%s' "$n" > %[2]q
+exec /bin/cat %[3]q/"$n".json
+`, argsLog, counter, dir)
+	bin := t.TempDir()
+	//nolint:gosec // G306: an executable stub on a test-owned temp PATH.
+	if err := os.WriteFile(filepath.Join(bin, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", bin)
+	return argsLog
+}
+
+func readArgsLog(t *testing.T, path string) string {
+	t.Helper()
+	//nolint:gosec // G304: a test-owned temp path, not user input.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func testOptions() Options { return Options{Timeout: 30 * time.Second} }
+
+// TestPlainifyPromptCarriesEveryConstraint proves each constraint reaches the
+// model, and that an unconstrained call carries no constraint block at all.
+func TestPlainifyPromptCarriesEveryConstraint(t *testing.T) {
+	bare := BuildPlainifySystemPrompt(PlainifyConstraints{})
+	for _, principle := range plainifyPrinciples {
+		if !strings.Contains(bare, principle) {
+			t.Fatalf("bare prompt is missing a standing principle: %q", principle)
+		}
+	}
+	if strings.Contains(bare, "constraints") {
+		t.Fatalf("bare prompt carries a constraint block:\n%s", bare)
+	}
+
+	full := BuildPlainifySystemPrompt(PlainifyConstraints{
+		MaxWords:    120,
+		Forbid:      []*regexp.Regexp{regexp.MustCompile(`\bDQ\d+\b`)},
+		NameByTitle: true,
+		Glossary:    map[string]string{"DQ4": "Worker transport", "DQ1": "Session identity"},
+	})
+	for _, want := range []string{
+		"at most 120 words",
+		`\bDQ\d+\b`,
+		"Name every item you refer to by its title",
+		`DQ4 is titled "Worker transport"`,
+	} {
+		if !strings.Contains(full, want) {
+			t.Fatalf("constrained prompt is missing %q:\n%s", want, full)
+		}
+	}
+	if strings.Index(full, "DQ1 is titled") > strings.Index(full, "DQ4 is titled") {
+		t.Fatalf("glossary entries are not sorted by identifier:\n%s", full)
+	}
+}
+
+// TestPlainifyRetriesOnceAndKeepsTheRetry drives a rewrite that busts the word
+// budget on the first attempt and fits on the second.
+func TestPlainifyRetriesOnceAndKeepsTheRetry(t *testing.T) {
+	argsLog := fakeClaudeSequence(t, "one two three four five", "one two three")
+
+	c := PlainifyConstraints{MaxWords: 4}
+	res, err := Plainify(context.Background(), "a long claudish paragraph", c, testOptions())
+	if err != nil {
+		t.Fatalf("Plainify: %v", err)
+	}
+	if res.Plain != "one two three" {
+		t.Fatalf("plain=%q, want the retry's answer", res.Plain)
+	}
+	if res.Words != 3 || res.Truncated {
+		t.Fatalf("words=%d truncated=%v, want 3 and false", res.Words, res.Truncated)
+	}
+	if len(res.Violations) != 0 {
+		t.Fatalf("violations=%+v, want none", res.Violations)
+	}
+
+	args := readArgsLog(t, argsLog)
+	if n := strings.Count(args, "--json-schema"); n != 2 {
+		t.Fatalf("claude was called %d times, want 2:\n%s", n, args)
+	}
+	if !strings.Contains(args, "ran to 5 words against a limit of 4") {
+		t.Fatalf("the retry never named the miss:\n%s", args)
+	}
+}
+
+// TestPlainifyReportsWhatTheRetryStillMisses is the no-silent-drop half: a
+// model that ignores the constraints twice yields a report, not an error and
+// not a scrubbed rewrite.
+func TestPlainifyReportsWhatTheRetryStillMisses(t *testing.T) {
+	const stubborn = "DQ4 and DQ7 both moved to the new transport"
+	fakeClaudeSequence(t, stubborn, stubborn)
+
+	c := PlainifyConstraints{
+		MaxWords: 3,
+		Forbid:   []*regexp.Regexp{regexp.MustCompile(`\bDQ\d+\b`)},
+	}
+	res, err := Plainify(context.Background(), "claudish input", c, testOptions())
+	if err != nil {
+		t.Fatalf("Plainify: %v", err)
+	}
+	if res.Plain != stubborn {
+		t.Fatalf("plain=%q, want the model's answer untouched", res.Plain)
+	}
+	if !res.Truncated || res.Words != 9 {
+		t.Fatalf("words=%d truncated=%v, want 9 and true", res.Words, res.Truncated)
+	}
+	want := []PlainViolation{
+		{Pattern: `\bDQ\d+\b`, Match: "DQ4"},
+		{Pattern: `\bDQ\d+\b`, Match: "DQ7"},
+	}
+	if fmt.Sprint(res.Violations) != fmt.Sprint(want) {
+		t.Fatalf("violations=%+v, want %+v", res.Violations, want)
+	}
+}
+
+// TestPlainifyLeavesAMetRewriteAlone checks the single-call path: no retry
+// fires when the first answer already meets the constraints.
+func TestPlainifyLeavesAMetRewriteAlone(t *testing.T) {
+	argsLog := fakeClaudeSequence(t, "  the worker moved  ")
+
+	res, err := Plainify(context.Background(), "input", PlainifyConstraints{MaxWords: 10}, testOptions())
+	if err != nil {
+		t.Fatalf("Plainify: %v", err)
+	}
+	if res.Plain != "the worker moved" {
+		t.Fatalf("plain=%q, want the trimmed answer", res.Plain)
+	}
+	if n := strings.Count(readArgsLog(t, argsLog), "--json-schema"); n != 1 {
+		t.Fatalf("claude was called %d times, want 1", n)
+	}
+}
+
+// fakeClaudeByMarker puts a claude stub on $PATH that answers from a marker
+// found in the text it is handed on stdin, sleeping for the marker's index so
+// the entries finish out of the order they were dispatched in. A marker
+// mapped to the empty rewrite exits 1 instead.
+func fakeClaudeByMarker(t *testing.T, markers []string, fail string) {
+	t.Helper()
+	dir := t.TempDir()
+	var arms strings.Builder
+	for i, marker := range markers {
+		if marker == fail {
+			fmt.Fprintf(&arms, "  *%s*) exit 1 ;;\n", marker)
+			continue
+		}
+		writePlainResponse(t, filepath.Join(dir, marker+".json"), "plain "+marker)
+		delay := float64(len(markers)-i) / 20.0
+		fmt.Fprintf(&arms, "  *%s*) /bin/sleep %.2f; exec /bin/cat %q ;;\n", marker, delay, filepath.Join(dir, marker+".json"))
+	}
+	script := "#!/bin/sh\nbody=$(/bin/cat)\ncase \"$body\" in\n" + arms.String() + "esac\nexit 1\n"
+	bin := t.TempDir()
+	//nolint:gosec // G306: an executable stub on a test-owned temp PATH.
+	if err := os.WriteFile(filepath.Join(bin, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+}
+
+func markerEntries(markers []string) []PlainEntry {
+	entries := make([]PlainEntry, 0, len(markers))
+	for _, marker := range markers {
+		entries = append(entries, PlainEntry{ID: "id-" + marker, Text: "claudish " + marker + " prose"})
+	}
+	return entries
+}
+
+// TestPlainifyBatchKeepsEntryOrder proves results come back paired with the
+// entry that produced them. There are more entries than concurrency slots, so
+// the run blocks on the semaphore, and each stub sleeps for its position so
+// the calls finish in reverse order.
+func TestPlainifyBatchKeepsEntryOrder(t *testing.T) {
+	markers := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta"}
+	if len(markers) <= plainifyConcurrency {
+		t.Fatalf("the batch needs more than %d entries to block on a slot", plainifyConcurrency)
+	}
+	fakeClaudeByMarker(t, markers, "")
+
+	results, err := PlainifyBatch(context.Background(), markerEntries(markers), PlainifyConstraints{}, testOptions())
+	if err != nil {
+		t.Fatalf("PlainifyBatch: %v", err)
+	}
+	if len(results) != len(markers) {
+		t.Fatalf("results=%d, want %d", len(results), len(markers))
+	}
+	for i, marker := range markers {
+		if want := "plain " + marker; results[i].Plain != want {
+			t.Fatalf("result %d is %q, want %q", i, results[i].Plain, want)
+		}
+	}
+}
+
+// TestPlainifyBatchNamesTheFailingEntry fails one entry away from index 0, so
+// an error attributed by position rather than by index shows up.
+func TestPlainifyBatchNamesTheFailingEntry(t *testing.T) {
+	markers := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta"}
+	fakeClaudeByMarker(t, markers, "epsilon")
+
+	_, err := PlainifyBatch(context.Background(), markerEntries(markers), PlainifyConstraints{}, testOptions())
+	if err == nil {
+		t.Fatal("PlainifyBatch: expected the stub's failure to propagate")
+	}
+	if !strings.Contains(err.Error(), "entry id-epsilon") {
+		t.Fatalf("error %q does not name the failing entry", err)
+	}
+}


### PR DESCRIPTION
Adds `slop-cop plainify`, a fourth command that rewrites a piece of prose into plain English instead of grading it. `check` says what is wrong with a draft and `rewrite` fixes the slop tells; neither turns prose written for people already inside a project into prose a reader outside it can follow. That last step is the one an agent hands to a human, and it was the one slop-cop could not do.

## What changed

- `internal/llm/plainify.go` carries the contract and the grading. The system prompt keeps every fact, name, number, and file path, asks for short sentences and everyday words, leaves fenced and inline code untouched, and returns the rewrite alone. `Plainify` grades the answer against the caller's constraints, retries once with each miss named, and returns the second attempt's grade, met or not.
- `cmd/slop-cop/plainify.go` mirrors `rewrite` down to the positional-or-stdin input, the `--pretty`, `--model`, and `--timeout` flags, the `claude -p` layer through `llm.RunSchema`, and the defaults. There is no second LLM client and no second model constant.
- `--max-words N` and `--forbid <regex>` reach the model as instructions and are checked again in Go once it answers, because an instruction is not a guarantee. What survives the retry is reported in `truncated` and `violations`, never scrubbed out of the rewrite. `--forbid` is repeatable and takes a raw pattern, so `--forbid 'finding \d{1,2}'` keeps its comma.
- `--name-by-title` asks for titles in place of identifiers, and `--glossary <file>` hands the model a JSON map from one to the other, sorted by identifier so the prompt is stable across runs.
- `--json` reads an array of `{"id","text"}` entries, runs one call per entry against a four-slot semaphore, and prints one `{"id","plain","words","truncated","violations"}` element per entry in the order they arrived. A JSON `null` is rejected instead of printed as an empty array; an empty array is a real answer and prints `[]`.
- The README gains a Commands row and a paragraph beside the existing LLM-tier prose. `rewrite` ships no `docs/` page, `commands/` file, or skill, so `plainify` adds none either.

## Verification

- `go build ./...`, `go vet ./...`, and `go test -race ./...` are green on macOS with Go 1.26.6, and `gofmt -l` is empty.
- Nine new tests fake the `claude` subprocess the way `internal/llm/claude_test.go` already does, replaying the captured stream-array response shape from a stub on an otherwise-empty `$PATH`. They cover every constraint reaching the system prompt, the retry firing once and keeping its own answer, and a model that ignores the constraints twice landing in `truncated` and `violations`. They also cover the batch holding entry order across a fan-out wider than the semaphore, with its stubs finishing in reverse, and an error naming the entry that caused it. The last two cover the `null` rejection and both malformed constraint flags mapping to the usage exit class.
- `slop-cop check README.md --lang=markdown --llm-effort=off` reports the same nine violations it reported before this branch. The three the first draft added are gone.

This branch does not fix cobra's own flag-parsing failures. `--max-words nope` still exits `2` instead of the `4` the root help documents for a usage error. That predates this branch and applies to every command, so it belongs in its own change.

Claude-Session: https://claude.ai/code/session_01YLWPNQ1DASVzC6bxQP4qLZ
