### PR TITLE
plugin: surface plainify as /slop-cop-plainify

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ When the base layer runs over at least 100 words of prose, the report also carri
 
 ## The agent plugin
 
-The [`slop-cop-prose`](skills/slop-cop-prose/SKILL.md) skill triggers whenever you ask the agent to write, revise, or polish prose, and keeps the loop silent; the agent never announces it. A [`/slop-cop-check`](commands/slop-cop-check.md) command runs a one-off report without rewriting anything.
+The [`slop-cop-prose`](skills/slop-cop-prose/SKILL.md) skill triggers whenever you ask the agent to write, revise, or polish prose, and keeps the loop silent; the agent never announces it. A [`/slop-cop-check`](commands/slop-cop-check.md) command runs a one-off report without rewriting anything, and [`/slop-cop-plainify`](commands/slop-cop-plainify.md) rewrites a file into plain English and shows the result beside the original.
 
 <details>
 <summary>Claude Code</summary>

--- a/commands/slop-cop-plainify.md
+++ b/commands/slop-cop-plainify.md
@@ -1,0 +1,59 @@
+---
+name: slop-cop-plainify
+description: "Rewrite a file or the current selection into plain English with slop-cop plainify, and show the rewrite beside the original. Usage: /slop-cop-plainify [path]"
+---
+
+# Slop Cop: plain English
+
+Run `slop-cop plainify` over the target prose and show the plain-English
+rewrite beside the original. For a violations report instead of a rewrite,
+use the `/slop-cop-check` command.
+
+## Usage
+
+- `/slop-cop-plainify`: rewrite the currently open file or the current
+  selection.
+- `/slop-cop-plainify <path>`: rewrite the file at `<path>`.
+- `/slop-cop-plainify -`: read the target text from stdin (useful for piping).
+
+## Instructions
+
+1. **Resolve the binary.** Prefer
+   `${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}/bin/slop-cop` — a committed
+   wrapper that locates the `binrun` runner and execs the exact release pinned
+   in `bin/slop-cop.binrun`, caching it after the first call. Fall back to
+   `slop-cop` on `$PATH` if neither plugin root is set.
+
+2. **Pick the target.** In order of preference:
+   - `$ARGUMENTS` if the user supplied a path or `-`.
+   - The current editor selection if any is non-empty.
+   - The currently focused file otherwise.
+
+3. **Invoke.** Run `slop-cop plainify --pretty <target>`, which keeps every
+   fact, name, number, and file path, writes short sentences in everyday
+   words, and leaves fenced and inline code unchanged. It drives the `claude`
+   CLI, so it needs no API key. Add the flags the user asked for:
+   - `--max-words <n>`: a word budget for the rewrite; `0` sets none.
+   - `--forbid <regex>`: a pattern the rewrite must not match; repeatable.
+   - `--name-by-title`: name referenced items by their titles, not their
+     identifiers.
+   - `--glossary <path>`: a JSON object mapping identifier to title, such as
+     `{"DQ4":"Worker transport"}`.
+   - `--json`: read a JSON array of `{"id","text"}` entries instead of one
+     piece of prose, and emit one result per entry in the order they arrived.
+
+   `--max-words` and `--forbid` reach the model as instructions and are graded
+   again after it answers. A rewrite that misses either is retried once with
+   its misses named.
+
+4. **Report.** Each result is
+   `{"plain": ..., "words": N, "truncated": bool, "violations": [...]}`, and
+   `--json` returns one of them per entry under its `id`. Present:
+   - The `plain` rewrite in full, beside the original text.
+   - The `words` count, against the budget when `--max-words` was set.
+   - `truncated: true` as a warning that the retry still ran past the budget.
+   - Each `violations` entry as its `pattern` and the `match` that survived
+     the retry.
+
+Do **not** write the rewrite over the source file. Show it beside the
+original and let the user decide what to keep.

--- a/skills/slop-cop-prose/SKILL.md
+++ b/skills/slop-cop-prose/SKILL.md
@@ -211,3 +211,28 @@ rate limit, or a timeout, slop-cop skips the auto-enabled pass and reports
 its error; the client-side output always returns. Inspect
 `llm_effort` and `llm.sentence` / `llm.document` in the JSON report to see
 what actually ran.
+
+## Plain-English twins
+
+`slop-cop check` grades one piece of prose. `slop-cop plainify` writes a
+second one: a plain-English twin of text that is precise but hard to read
+cold, such as a register entry, a review finding, or a recorded decision. The
+twin sits beside the original, and the original stays authoritative.
+
+Reach for it whenever the reader sits outside the project. A finding that
+names `DQ4` reads fine to whoever wrote it and not at all to anyone else, and
+the same goes for claudish, the prose an agent writes for other agents.
+Plainify turns both into something a reader follows on one pass.
+
+```bash
+"$SLOP_COP" plainify draft.md --max-words 120 --name-by-title --glossary titles.json
+```
+
+The rewrite keeps every fact, name, number, and file path, and leaves fenced
+and inline code alone. `--max-words` and `--forbid <regex>` reach the model as
+instructions and are graded again once it answers, so
+`--forbid '\b(DQ|A|Q|V)\d+\b'` catches an identifier the rewrite kept. What a
+retry still misses lands in the result's `truncated` and `violations` fields
+instead of being dropped. `--json` reads an array of `{"id","text"}` entries
+and returns one result per entry, in the order they arrived. The
+`/slop-cop-plainify` command runs the same rewrite as a one-off.


### PR DESCRIPTION
`slop-cop plainify` shipped as a CLI command and stopped there. The plugin the repo ships surfaced `check` and nothing else, so an agent had to already know the command existed to reach the one step it hands to a human. This wires plainify into the plugin the same way check is wired.

## What changed

- `commands/slop-cop-plainify.md` mirrors `/slop-cop-check` down to its shape: the same frontmatter keys, the same binary-resolution step through the committed `bin/slop-cop` wrapper with a `$PATH` fallback, and the same target order of `$ARGUMENTS`, then the selection, then the focused file. It documents `--max-words`, `--forbid`, `--name-by-title`, `--glossary`, and `--json` from the command's own help text, and it closes on the rule that matters for a rewrite command: show the plain text beside the original, never over it.
- The `slop-cop-prose` skill gains a "Plain-English twins" section. `check` grades one piece of prose; plainify writes a second one, a plain-English twin of text that is precise but hard to read cold, such as a register entry, a review finding, or a recorded decision. It names when to reach for that, including claudish, the prose an agent writes for other agents, and carries the one-line invocation with the constraint flags. The section sits at the end because the skill documents `check` and not `rewrite`, so there was no rewrite section to sit beside.
- The README's plugin paragraph names the new command next to `/slop-cop-check`.

## Registration

Both manifests point at the directory, not at individual commands. `.cursor-plugin/plugin.json` carries `"commands": "./commands/"` and `.claude-plugin/plugin.json` carries no command list at all, so a new file in `commands/` is registered by existing. Neither version is bumped by hand: the release workflow's `descriptor` job rewrites `.claude-plugin/plugin.json` from the tag and `cursor-bump` does the same for the Cursor manifest, each gated on the descriptor agreeing.

## Verification

`go build ./...` and `go test ./...` pass; no Go changed. `claude plugin validate .` passes with one pre-existing warning about the marketplace description. `slop-cop check --lang=markdown --llm-effort=off` over the three touched files leaves the new command file at 13 violations against `/slop-cop-check`'s 14, all of them the colon, em-dash, and `currently` hits it mirrors verbatim; the skill gains one colon hit and the README none.

https://claude.ai/code/session_01YLWPNQ1DASVzC6bxQP4qLZ
