### PR TITLE
deps: bump spawnllm to v0.13.0 so spawned claude skips host hooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-javascript v0.25.0
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
-	github.com/yasyf/spawnllm/go v0.12.0
+	github.com/yasyf/spawnllm/go v0.13.0
 	github.com/yuin/goldmark v1.8.2
 	golang.org/x/net v0.53.0
 )

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/tree-sitter/tree-sitter-rust v0.23.2 h1:6AtoooCW5GqNrRpfnvl0iUhxTAZEo
 github.com/tree-sitter/tree-sitter-rust v0.23.2/go.mod h1:hfeGWic9BAfgTrc7Xf6FaOAguCFJRo3RBbs7QJ6D7MI=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
-github.com/yasyf/spawnllm/go v0.12.0 h1:9hn7IZyom3o6rmKx+BIAiGQ5Ft+GwkdlEIoM/sYFNbw=
-github.com/yasyf/spawnllm/go v0.12.0/go.mod h1:CDwzU8+zKWO8Bp4Soxtj3ZxQCj+e1BP4te3r4ARayzo=
+github.com/yasyf/spawnllm/go v0.13.0 h1:a1Q9rCAsEssSM/HiJ+87ohlgs9QfPYMuYlckqCem8VE=
+github.com/yasyf/spawnllm/go v0.13.0/go.mod h1:CDwzU8+zKWO8Bp4Soxtj3ZxQCj+e1BP4te3r4ARayzo=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=


### PR DESCRIPTION
Bumps `github.com/yasyf/spawnllm/go` from v0.12.0 to v0.13.0. One line in `go.mod`, but it revives a feature that was dead in practice on any machine with a real hook stack, the sentence tier of `slop-cop check`.

## What changed

spawnllm v0.13.0 adds `setting_sources` to its claude backend and defaults it to `--setting-sources project`. A spawned `claude` session no longer inherits the host's user-level settings, and in particular no longer inherits the host's hooks. `RunSchema` in `internal/llm/claude.go` sets `UseHostConfig: true` so the caller's credentials stay reachable, and with v0.12.0 that same flag handed every LLM call the caller's whole hook stack. On a machine with a real hook stack the hooks dominated the call.

## Measurement

Identical work on both sides. `slop-cop check` on a one-line Markdown file, two runs each, same machine, binaries built from this branch and from `origin/main` in a separate worktree. The "before" column is the real old dependency, not a reconstruction.

| spawnllm | run 1 | run 2 | sentence tier |
|---|---|---|---|
| v0.12.0 | 122.4s | 122.4s | never ran; `claude timed out after 2m0s` |
| v0.13.0 | 100.3s | 39.1s | ran |

Before the bump, the sentence tier hit `DefaultSentenceTimeout` (120s) on every run and was skipped. An auto-resolved effort level fails open, so the skip was silent. The report still came back, just without the 40 sentence-tier rules. Users saw a slow command and a report built only from the client-side rules, never an error.

The same machine supplies the supporting numbers. A bare `claude -p` one-word prompt in the shape spawnllm used to build took 63.0s and printed `SessionEnd hook … failed: Hook cancelled`. With `--setting-sources project` it took 6.4s, 7.5s, and 5.7s across three runs. `--settings '{"hooks":{}}'` is not a workaround, because settings merge; it measured 44.7s with the hooks still running. On a real 5,788-byte README, split into two chunks analyzed in parallel, the tier now completes and finds 4 violations the client-side rules cannot see, 33 with the tier against 29 with `--llm-effort=off`.

## What this does not fix

The command is still slow and can still time out on larger inputs. The residual 39s to 100s per call is inference over the sentence-tier rule prompt plus the JSON-schema structured output, not spawn overhead. A one-line document costs about 30s where a bare one-word prompt costs 6s, and machine load moves it a lot. Two chunks of a real README can still exceed the 120s budget. The remaining levers are a faster model for the tier, a longer timeout, or a smaller prompt; none of them are in this PR.

## Verification

`go build ./...` succeeds. The timings above come from binaries built from this branch and from `origin/main` in a separate worktree.

https://claude.ai/code/session_014gKfZvjihGgFrEVCr3NJJb
