### PR TITLE
cask: strip the quarantine xattr on install so the first exec cannot block on Gatekeeper

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,6 +77,12 @@ homebrew_casks:
     ids: [slop-cop]
     binaries:
       - slop-cop
+    # Quarantined cask binaries block the first exec on a Gatekeeper consent
+    # dialog, before dyld runs — no headless agent can answer it.
+    hooks:
+      post:
+        install: |
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/slop-cop"]
     repository:
       owner: yasyf
       name: homebrew-tap

--- a/internal/releasecontract/cask_test.go
+++ b/internal/releasecontract/cask_test.go
@@ -1,0 +1,56 @@
+package releasecontract
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func caskSection(t *testing.T) string {
+	t.Helper()
+	_, source, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate test source")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(source), "..", ".."))
+	data, err := os.ReadFile(filepath.Join(root, ".goreleaser.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var section []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "homebrew_casks:") {
+			section = []string{line}
+			continue
+		}
+		if section == nil {
+			continue
+		}
+		if trimmed := strings.TrimSpace(line); trimmed != "" && !strings.HasPrefix(trimmed, "#") && !strings.HasPrefix(line, " ") {
+			break
+		}
+		section = append(section, line)
+	}
+	if section == nil {
+		t.Fatal("no homebrew_casks section")
+	}
+	return strings.Join(section, "\n")
+}
+
+func TestCaskInstallHookClearsQuarantine(t *testing.T) {
+	cask := caskSection(t)
+	for _, required := range []string{
+		"hooks:",
+		"post:",
+		"install:",
+		`system_command "/usr/bin/xattr"`,
+		`"-dr", "com.apple.quarantine"`,
+		"#{staged_path}/slop-cop",
+	} {
+		if !strings.Contains(cask, required) {
+			t.Errorf("cask missing %q", required)
+		}
+	}
+}


### PR DESCRIPTION
## Context

slop-cop installed through the Homebrew cask hangs on its first run after every install or upgrade — indefinitely, not slowly. One machine had 14 processes wedged at once: a `slop-cop --version` running for 6h12m, a `--help` at 1h53m, and `check` invocations between 16 and 34 minutes.

`--version` and `--help` hanging is the tell, because they do no work. All 1587 samples of a wedged process sit on `_dyld_start + 0` with no libraries loaded and a 128 KB footprint. `ps` shows 0:00.00 CPU and 48–96 KB RSS after half an hour, where a running Go binary sits at 10–30 MB. The Go runtime never starts, so nothing in this repository can be the cause.

Gatekeeper is. `syspolicyd` logged two consent prompts in ten hours, both for slop-cop, neither ever answered:

```
GK evaluateScanResult: 0, PST: (team: SXKCTF23Q2), (id: slop-cop), ...
Prompt shown (5, 0), waiting for response: PST: (team: SXKCTF23Q2), (id: slop-cop)
```

That timestamp is the moment `brew upgrade` rewrote the `/opt/homebrew/bin/slop-cop` symlink, and it lines up with the 6h12m hang. Homebrew Cask stages binaries carrying `com.apple.quarantine`. The first exec of a CDHash with no cached verdict triggers an assessment that puts a GUI dialog on screen; on a headless or unattended invocation nobody answers, and the exec blocks in the kernel.

Notarization is not the problem — `spctl` reports `accepted, source=Notarized Developer ID`. The quarantine flag is, and the correlation is clean: all 12 wedged processes inspected with `lsof` mapped to the quarantined Caskroom copy, and zero mapped to a mise-installed copy of the same tool, which carries no quarantine xattr. Gatekeeper caches per CDHash, so this fires once per install or upgrade, which is why it looked intermittent.

## Changes

- `.goreleaser.yaml` gives the cask a post-install hook that strips the xattr from the staged binary, so the first exec never reaches Gatekeeper's consent path.
- `internal/releasecontract/cask_test.go` adds `TestCaskInstallHookClearsQuarantine`, asserting the hook, the `xattr` invocation, its `-dr com.apple.quarantine` arguments, and the `#{staged_path}/slop-cop` target are all present in the release config.

## Testing

The diagnosis rests on the syspolicyd log and the quarantine correlation, not on a reproduction. Clearing a cached CDHash verdict needs root access to `/var/db/SystemPolicy`, and the hang will not trigger on demand: 40 serial execs, 24 concurrent execs, and 120 execs A/B-ing a hand-quarantined copy against a clean one produced zero hangs.

There is no useful runtime test for the same reason — Gatekeeper caches per CDHash, so only the first exec after an install can prompt, and a timing test would pass identically on fixed and unfixed machines. The contract test over the release config is what distinguishes the two states, and it was verified failing against the unfixed config:

```
=== RUN   TestCaskInstallHookClearsQuarantine
    cask_test.go:53: cask missing "hooks:"
    cask_test.go:53: cask missing "system_command \"/usr/bin/xattr\""
--- FAIL: TestCaskInstallHookClearsQuarantine (0.00s)
```

`goreleaser check` passes, `gofmt -l` is empty, `go vet ./...` is silent, `go test ./...` is green across every package, and `prek run` reports every hook passing.

## Note for anyone already stuck

Until a release carrying this lands, clear the flag by hand:

```sh
xattr -dr com.apple.quarantine "$(brew --prefix)/Caskroom/slop-cop"
pkill -9 -x slop-cop
```
