### PR TITLE
tests: cut the provider stubs to one execve per call

### DIFF
--- a/cmd/slop-cop/plainify_test.go
+++ b/cmd/slop-cop/plainify_test.go
@@ -37,6 +37,12 @@ func runPlainify(t *testing.T, args ...string) (string, error) {
 	return string(out), runErr
 }
 
+// shQuote renders s as a single-quoted shell word, so a stub can carry a JSON
+// payload in its own body.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 // claudeReplying puts a claude stub on an otherwise-empty $PATH that answers
 // every call with the same rewrite, and returns the path it logs each call's
 // arguments to.
@@ -58,13 +64,14 @@ func claudeReplying(t *testing.T, plain string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	response := filepath.Join(dir, "response.json")
-	//nolint:gosec // G306: a fixture in a test-owned temp dir.
-	if err := os.WriteFile(response, raw, 0o644); err != nil {
-		t.Fatal(err)
-	}
 	argsLog := filepath.Join(dir, "args")
-	script := fmt.Sprintf("#!/bin/sh\n/bin/cat > /dev/null\nprintf '%%s\\n' \"$*\" >> %q\nexec /bin/cat %q\n", argsLog, response)
+	// The stub runs on shell builtins alone: spawning cat costs a second
+	// execve per call, which under the endpoint-security agents that inspect
+	// every exec on a Mac is ~0.3s rather than microseconds.
+	script := fmt.Sprintf(
+		"#!/bin/sh\nwhile IFS= read -r line; do :; done\nprintf '%%s\\n' \"$*\" >> %q\nprintf '%%s' %s\n",
+		argsLog, shQuote(string(raw)),
+	)
 	bin := t.TempDir()
 	//nolint:gosec // G306: an executable stub on a test-owned temp PATH.
 	if err := os.WriteFile(filepath.Join(bin, "claude"), []byte(script), 0o755); err != nil {

--- a/internal/llm/plainify_test.go
+++ b/internal/llm/plainify_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 )
 
-// writePlainResponse renders one captured-shape `claude -p --output-format
-// json` reply — the stream array whose terminal type=="result" element carries
-// the schema payload — for a given rewrite.
-func writePlainResponse(t *testing.T, path, plain string) {
+// plainResponse renders one captured-shape `claude -p --output-format json`
+// reply — the stream array whose terminal type=="result" element carries the
+// schema payload — for a given rewrite.
+func plainResponse(t *testing.T, plain string) string {
 	t.Helper()
 	payload, err := json.Marshal(plainifyEnvelope{Plain: plain})
 	if err != nil {
@@ -36,10 +36,7 @@ func writePlainResponse(t *testing.T, path, plain string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//nolint:gosec // G306: a fixture in a test-owned temp dir.
-	if err := os.WriteFile(path, raw, 0o644); err != nil {
-		t.Fatal(err)
-	}
+	return string(raw)
 }
 
 // fakeClaudeSequence puts a claude stub on an otherwise-empty $PATH that
@@ -48,27 +45,23 @@ func writePlainResponse(t *testing.T, path, plain string) {
 // attempt was given.
 func fakeClaudeSequence(t *testing.T, plains ...string) string {
 	t.Helper()
-	dir := t.TempDir()
+	state := t.TempDir()
+	counter := filepath.Join(state, "calls")
+	argsLog := filepath.Join(state, "args")
+
+	var arms strings.Builder
 	for i, plain := range plains {
-		writePlainResponse(t, filepath.Join(dir, fmt.Sprintf("%d.json", i+1)), plain)
+		fmt.Fprintf(&arms, "\t%d) %s ;;\n", i+1, printPayload(plainResponse(t, plain)))
 	}
-	counter := filepath.Join(dir, "calls")
-	argsLog := filepath.Join(dir, "args")
-	script := fmt.Sprintf(`#!/bin/sh
-/bin/cat > /dev/null
-printf '%%s\n' "$*" >> %[1]q
+	writeStub(t, "claude", fmt.Sprintf(`%[1]sprintf '%%s\n' "$*" >> %[2]q
 n=0
-if [ -f %[2]q ]; then n=$(/bin/cat %[2]q); fi
+if [ -f %[3]q ]; then read -r n < %[3]q; fi
 n=$((n+1))
-printf '%%s' "$n" > %[2]q
-exec /bin/cat %[3]q/"$n".json
-`, argsLog, counter, dir)
-	bin := t.TempDir()
-	//nolint:gosec // G306: an executable stub on a test-owned temp PATH.
-	if err := os.WriteFile(filepath.Join(bin, "claude"), []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake claude: %v", err)
-	}
-	t.Setenv("PATH", bin)
+printf '%%s\n' "$n" > %[3]q
+case "$n" in
+%[4]s	*) exit 1 ;;
+esac
+`, drainStdin, argsLog, counter, arms.String()))
 	return argsLog
 }
 
@@ -200,24 +193,18 @@ func TestPlainifyLeavesAMetRewriteAlone(t *testing.T) {
 // mapped to the empty rewrite exits 1 instead.
 func fakeClaudeByMarker(t *testing.T, markers []string, fail string) {
 	t.Helper()
-	dir := t.TempDir()
 	var arms strings.Builder
 	for i, marker := range markers {
 		if marker == fail {
 			fmt.Fprintf(&arms, "  *%s*) exit 1 ;;\n", marker)
 			continue
 		}
-		writePlainResponse(t, filepath.Join(dir, marker+".json"), "plain "+marker)
 		delay := float64(len(markers)-i) / 20.0
-		fmt.Fprintf(&arms, "  *%s*) /bin/sleep %.2f; exec /bin/cat %q ;;\n", marker, delay, filepath.Join(dir, marker+".json"))
+		fmt.Fprintf(&arms, "  *%s*) /bin/sleep %.2f; %s ;;\n", marker, delay, printPayload(plainResponse(t, "plain "+marker)))
 	}
-	script := "#!/bin/sh\nbody=$(/bin/cat)\ncase \"$body\" in\n" + arms.String() + "esac\nexit 1\n"
-	bin := t.TempDir()
-	//nolint:gosec // G306: an executable stub on a test-owned temp PATH.
-	if err := os.WriteFile(filepath.Join(bin, "claude"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin)
+	writeStub(t, "claude", "body=\n"+
+		"while IFS= read -r line || [ -n \"$line\" ]; do body=\"$body$line\"; done\n"+
+		"case \"$body\" in\n"+arms.String()+"  *) exit 1 ;;\nesac\n")
 }
 
 func markerEntries(markers []string) []PlainEntry {

--- a/internal/llm/prompts_test.go
+++ b/internal/llm/prompts_test.go
@@ -139,18 +139,11 @@ func TestBasePromptCarriesOnlyBaseRules(t *testing.T) {
 // prompt codex is fed, not merely be dropped from the response. spawnllm
 // delivers the prompt on stdin, so that is what the stand-in captures.
 func TestOptionsRulesReachTheProcess(t *testing.T) {
-	response := writeResponse(t, `{"violations":[]}`)
 	capture := filepath.Join(t.TempDir(), "stdin")
-	dir := t.TempDir()
-	script := fmt.Sprintf(
-		"#!/bin/sh\n/bin/cat > %q\nwhile [ $# -gt 0 ]; do\n\tif [ \"$1\" = -o ]; then exec /bin/cat %q >\"$2\"; fi\n\tshift\ndone\n",
-		capture, response,
-	)
-	//nolint:gosec // G306: an executable stub on a test-owned temp PATH.
-	if err := os.WriteFile(filepath.Join(dir, "codex"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", dir)
+	writeStub(t, "codex", fmt.Sprintf(
+		"while IFS= read -r line || [ -n \"$line\" ]; do printf '%%s\\n' \"$line\"; done > %q\n%s",
+		capture, codexWriteResult(`{"violations":[]}`),
+	))
 
 	if _, err := RunSentence(context.Background(), "Some prose to analyse.", Options{
 		Timeout: 30 * time.Second,

--- a/internal/llm/run_test.go
+++ b/internal/llm/run_test.go
@@ -13,46 +13,53 @@ import (
 	spawnllm "github.com/yasyf/spawnllm/go"
 )
 
-// fakeClaude puts an executable named claude on an otherwise-empty $PATH
-// that ignores its arguments and prints the response file to stdout.
-func fakeClaude(t *testing.T, responsePath string) {
+// The stub bodies in this package run on shell builtins alone. Spawning cat
+// costs a second execve per call, which under the endpoint-security agents
+// that inspect every exec on a Mac is ~0.3s rather than microseconds.
+const drainStdin = "while IFS= read -r line; do :; done\n"
+
+// shQuote renders s as a single-quoted shell word, so a stub can carry a JSON
+// payload in its own body.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// printPayload is a stub command writing payload to stdout.
+func printPayload(payload string) string {
+	return "printf '%s' " + shQuote(payload)
+}
+
+// codexWriteResult is a stub fragment scanning argv for -o and writing payload
+// to the path after it, which is where spawnllm reads a codex result from.
+func codexWriteResult(payload string) string {
+	return "while [ $# -gt 0 ]; do\n\tif [ \"$1\" = -o ]; then printf '%s' " +
+		shQuote(payload) + " > \"$2\"; exit 0; fi\n\tshift\ndone\n"
+}
+
+// writeStub puts an executable named name, running body, on an
+// otherwise-empty $PATH.
+func writeStub(t *testing.T, name, body string) {
 	t.Helper()
 	dir := t.TempDir()
-	script := fmt.Sprintf("#!/bin/sh\nexec /bin/cat %q\n", responsePath)
 	//nolint:gosec // G306: an executable stub on a test-owned temp PATH.
-	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake claude: %v", err)
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatalf("write fake %s: %v", name, err)
 	}
 	t.Setenv("PATH", dir)
+}
+
+// fakeClaude puts an executable named claude on an otherwise-empty $PATH
+// that ignores its arguments and prints payload to stdout.
+func fakeClaude(t *testing.T, payload string) {
+	t.Helper()
+	writeStub(t, "claude", drainStdin+printPayload(payload)+"\n")
 }
 
 // fakeCodex puts an executable named codex on an otherwise-empty $PATH that
-// copies the response file to the -o path, which is where spawnllm reads a
-// codex result from.
-func fakeCodex(t *testing.T, responsePath string) {
+// answers with payload.
+func fakeCodex(t *testing.T, payload string) {
 	t.Helper()
-	dir := t.TempDir()
-	script := fmt.Sprintf(
-		"#!/bin/sh\nwhile [ $# -gt 0 ]; do\n\tif [ \"$1\" = -o ]; then exec /bin/cat %q >\"$2\"; fi\n\tshift\ndone\n",
-		responsePath,
-	)
-	//nolint:gosec // G306: an executable stub on a test-owned temp PATH.
-	if err := os.WriteFile(filepath.Join(dir, "codex"), []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake codex: %v", err)
-	}
-	t.Setenv("PATH", dir)
-}
-
-// writeResponse writes payload to a file in a test-owned temp dir and returns
-// its absolute path.
-func writeResponse(t *testing.T, payload string) string {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "response.json")
-	//nolint:gosec // G306: a fixture copy in a test-owned temp dir.
-	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	return path
+	writeStub(t, "codex", codexWriteResult(payload))
 }
 
 // TestRunSchemaStreamArray replays a real captured `claude -p --output-format
@@ -60,11 +67,12 @@ func writeResponse(t *testing.T, payload string) string {
 // element carries the schema payload — and proves RunSchema extracts and
 // decodes it.
 func TestRunSchemaStreamArray(t *testing.T) {
-	fixture, err := filepath.Abs(filepath.Join("testdata", "claude_stream_array.json"))
+	//nolint:gosec // G304: a fixed testdata path, not user input.
+	fixture, err := os.ReadFile(filepath.Join("testdata", "claude_stream_array.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	fakeClaude(t, fixture)
+	fakeClaude(t, string(fixture))
 
 	cfg := Config{Provider: spawnllm.ProviderClaude, Model: DefaultRewriteModel, Timeout: 30 * time.Second}
 	var env violationsEnvelope
@@ -104,8 +112,7 @@ func TestRunSchemaPanicsOnAnUnroutedProvider(t *testing.T) {
 // UTF-8 byte offsets in the original input.
 func TestRunSentenceResolvesByteOffsets(t *testing.T) {
 	const text = "Café rules. We utilize this approach."
-	payload := `{"violations":[{"ruleId":"elevated-register","matchedText":"utilize","explanation":"register","suggestedChange":"use"}]}`
-	fakeCodex(t, writeResponse(t, payload))
+	fakeCodex(t, `{"violations":[{"ruleId":"elevated-register","matchedText":"utilize","explanation":"register","suggestedChange":"use"}]}`)
 
 	vs, err := RunSentence(context.Background(), text, Options{Timeout: 30 * time.Second})
 	if err != nil {


### PR DESCRIPTION
Rewrites the `claude` and `codex` provider stubs in four test files so each stubbed call costs one `execve` instead of three or four. No production file changes, the NOTICE-derived files are untouched, and coverage is byte-for-byte the same. The same stubs answer the same calls with the same payloads under the same assertions, including the real concurrent subprocesses in `TestPlainifyBatchKeepsEntryOrder`.

## The diagnosis that was wrong

This opened as "the tests shell out to a real `claude` CLI with no skip guard, and CI is green only because `claude` is absent there." Every part of that was false, and the lane disproved it before writing a line. The tests already stub both providers on `$PATH` through `t.Setenv` across six files, and those helpers predate this work. Scrubbing both real binaries off `$PATH` leaves both the results and the runtime unchanged. CI runs `internal/llm` green in 3.71s because the stubs answer, so the success paths do run there.

What is slow is this machine's exec floor. An endpoint-security agent inspects every exec, measured at about 0.28s for a bare spawn and about 0.82s for a `sh` plus `cat` stub that costs two `execve`. The suite made about 25 such calls, which is the 20s.

## What changed

The stubs were spawning `cat` three ways, draining stdin with `/bin/cat > /dev/null`, reading a call counter with `n=$(/bin/cat FILE)`, and emitting the response with `exec /bin/cat FILE`, so some calls cost four `execve`. The payload now travels in the stub's own body through `printf '%s'`, stdin drains through a builtin `read` loop, the counter reads with `read -r n < FILE`, and response selection is a `case`. That is one `execve` per call. A shared `writeStub` helper in `internal/llm/run_test.go` routes every stub in the package, and `cmd/slop-cop` keeps its own three-line `shQuote`, since test helpers do not cross packages.

Measured back to back in one worktree at load 4.39 and then 4.38, `internal/llm` went from 20.898s to 12.667s and `cmd/slop-cop` from 12.678s to 6.318s, 21.4s to 13.2s wall. Per test, `PlainifyBatchKeepsEntryOrder` went 4.08s to 2.39s, `PlainifyRetriesOnce` 2.85s to 1.19s, and `RunSentenceResolvesByteOffsets` 1.29s to 0.53s.

Those totals hold only at the load they were taken at. Absolute timings on this machine are load-dominated and do not reproduce between runs; an independent run of the same tree at load 5.6 measured `cmd/slop-cop` at 61.164s, five times the 12.7s to 6.3s pair. The durable claim is the per-test ratio, which halves across the board, and the execve count per stubbed call, which the diff makes one. The wall-clock totals are a snapshot with its load named.

What remains is deliberate. Of `internal/llm`'s 12.7s, 3.00s is `TestRunSchemaBoundsTheRetryLoop` asserting its own 3s budget, and about 5s is twelve `/bin/sleep` execs in the two batch tests, which exist to force out-of-order completion. Of `cmd/slop-cop`'s 6.3s, 3.15s is `TestAutoPassTimeoutKeepsClientResults` against its 3s budget. None of that is waste.

The limit is worth stating plainly. This roughly doubles the headroom against the load-starvation flake; it does not eliminate it. The residual is the machine's exec tax, not a defect in this repository, and the same starvation hits any subprocess test on that box.

## A dead delay, filed and not fixed

Both retryable-codex stubs call a bare `sleep`, but their `$PATH` holds only the stub directory, so `sleep` never resolves and the delay never happens. Run by hand, the stub prints `sleep: command not found` to stderr and then continues. The tests still pass and still prove what they claim, because spawnllm's own backoff supplies the elapsed time, which makes `fakeRetryableCodex`'s `delay` parameter and the `sleep 0.2` in `pathWithRetryableCodex` dead. The two sites are `internal/llm/run_test.go:141` and `cmd/slop-cop/check_llm_timeout_test.go:17`. It is left alone here, since fixing it means either adding back an `execve` or changing a helper's contract, and it is filed as its own task.

## Verification

`gofmt -l` and `gofumpt -l` are clean, `go vet ./...` is clean, `go test ./... -count=1` is green, and `go test -race` is green at 15.9s for `internal/llm` and 13.4s for `cmd/slop-cop`. A two-way `$PATH` proof on the final tree, providers present against both scrubbed, measured 12.709s and 6.386s against 12.884s and 6.478s, identical within noise. golangci-lint is CI's gate, and `.golangci.yml` says not to invoke it by hand.

https://claude.ai/code/session_01WwXw5YPX7dAuwCkroepGMW
